### PR TITLE
Update kata's PHP version

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -11,7 +11,12 @@
     },
     "autoload": {
         "psr-4" : {
-            "CodeKata\\": ["src/CodeKata", "tests/CodeKata"]
+            "CodeKata\\": "src/CodeKata"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "CodeKata\\Tests\\": "tests/CodeKata"
         }
     }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -3,7 +3,7 @@
     "description": "Device Driver Kata",
     "license": "MIT",
     "require": {
-        "php": "^5.6"
+        "php": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "1.2.*",

--- a/php/composer.json
+++ b/php/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "phpunit/phpunit": "^9.1|^10.0"
+        "phpunit/phpunit": "^9.1|^10.0|^11.0"
     },
     "autoload": {
         "psr-4" : {

--- a/php/composer.json
+++ b/php/composer.json
@@ -6,8 +6,8 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "mockery/mockery": "1.2.*",
-        "phpunit/phpunit": "5.7.*"
+        "mockery/mockery": "^1.5",
+        "phpunit/phpunit": "^9.1|^10.0"
     },
     "autoload": {
         "psr-4" : {

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dojo/device-driver-kata",
-    "description": "device driver kata",
+    "description": "Device Driver Kata",
     "require": {
         "php": "^5.6"
     },

--- a/php/composer.json
+++ b/php/composer.json
@@ -16,7 +16,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "CodeKata\\Tests\\": "tests/CodeKata"
+            "Tests\\": "tests/CodeKata"
         }
     }
 }

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "dojo/device-driver-kata",
     "description": "Device Driver Kata",
+    "license": "MIT",
     "require": {
         "php": "^5.6"
     },
@@ -12,6 +13,5 @@
         "psr-4" : {
             "CodeKata\\": ["src/CodeKata", "tests/CodeKata"]
         }
-    },
-    "license": "MIT"
+    }
 }

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
-        backupGlobals="false"
-        bootstrap="./vendor/autoload.php"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        beStrictAboutTestsThatDoNotTestAnything="true"
-        beStrictAboutOutputDuringTests="true"
-        beStrictAboutTestSize="true"
-        beStrictAboutTodoAnnotatedTests="true"
-        verbose="false">
+<phpunit backupGlobals="false"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestSize="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="false">
     <testsuites>
         <testsuite name="All Tests">
             <directory suffix="Test.php">./tests</directory>

--- a/php/src/CodeKata/DeviceDriver.php
+++ b/php/src/CodeKata/DeviceDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CodeKata;
 
 /**
@@ -20,7 +22,7 @@ class DeviceDriver
      * @param int $address
      * @return int
      */
-    public function read($address)
+    public function read(int $address): int
     {
         return -1;
     }
@@ -28,8 +30,9 @@ class DeviceDriver
     /**
      * @param int $address
      * @param int $data
+     * @return void
      */
-    public function write($address, $data)
+    public function write(int $address, int $data): void
     {
         // TODO: implement this method
     }

--- a/php/src/CodeKata/DeviceDriver.php
+++ b/php/src/CodeKata/DeviceDriver.php
@@ -4,8 +4,8 @@
 namespace CodeKata;
 
 /**
- * This class is used by the operating system to interact with the hardware 'FlashMemoryDevice'.
- * @package CodeKata
+ * This class is used by the operating system to interact
+ * with the hardware 'FlashMemoryDevice'. @see FlashMemoryDevice
  */
 class DeviceDriver
 {

--- a/php/src/CodeKata/DeviceDriver.php
+++ b/php/src/CodeKata/DeviceDriver.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace CodeKata;
 
 /**
@@ -14,7 +13,7 @@ class DeviceDriver
      */
     public function __construct($hardware)
     {
-    // TODO: implement this method
+        // TODO: implement this method
     }
 
     /**
@@ -32,6 +31,6 @@ class DeviceDriver
      */
     public function write($address, $data)
     {
-    // TODO: implement this method
+        // TODO: implement this method
     }
 }

--- a/php/src/CodeKata/FlashMemoryDevice.php
+++ b/php/src/CodeKata/FlashMemoryDevice.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace CodeKata;
 
@@ -13,13 +14,14 @@ interface FlashMemoryDevice
 {
     /**
      * @param int $address
-     * @return int mixed
+     * @return int
      */
-    public function read($address);
+    public function read(int $address): int;
 
     /**
      * @param int $address
      * @param int $data
+     * @return void
      */
-    public function write($address, $data);
+    public function write(int $address, int $data): void;
 }

--- a/php/src/CodeKata/FlashMemoryDevice.php
+++ b/php/src/CodeKata/FlashMemoryDevice.php
@@ -6,9 +6,7 @@ namespace CodeKata;
 
 /**
  * This class represents the interface to a Flash Memory Device. The hardware has only two methods - 'read' and 'write'
- * However, the interface for using the device is a lot more complex than that.
- * It is outlined in the top-level README file.
- * @package CodeKata
+ * However, the interface for using the device is a lot more complex than that. It is outlined in the top-level README file.
  */
 interface FlashMemoryDevice
 {

--- a/php/tests/CodeKata/DeviceDriverTest.php
+++ b/php/tests/CodeKata/DeviceDriverTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace CodeKata\Tests;
 
 namespace CodeKata;
 

--- a/php/tests/CodeKata/DeviceDriverTest.php
+++ b/php/tests/CodeKata/DeviceDriverTest.php
@@ -2,9 +2,11 @@
 
 namespace CodeKata\Tests;
 
-namespace CodeKata;
+use CodeKata\DeviceDriver;
+use CodeKata\FlashMemoryDevice;
+use PHPUnit\Framework\TestCase;
 
-class DeviceDriverTest extends \PHPUnit_Framework_TestCase
+class DeviceDriverTest extends TestCase
 {
 
     public function testReadFromHardware()

--- a/php/tests/CodeKata/DeviceDriverTest.php
+++ b/php/tests/CodeKata/DeviceDriverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CodeKata\Tests;
+namespace Tests;
 
 use CodeKata\DeviceDriver;
 use CodeKata\FlashMemoryDevice;


### PR DESCRIPTION
Hello,

I would like to propose a few changes to the PHP version:

- bump PHP and its dependencies (`8.0` is already deprecated, but some people still use it, or I can increase the min version to `8.1`)
- add parameter types and return types to method signatures in the interface and main class (and add `strict_types` directive)
- change the namespace for tests (to keep production code and testing code in different namespaces)
- update `phpunit.xml` and remove XML schema (because different versions of phpunit are now available)
- some style improvements

